### PR TITLE
Import Dimensions from Usage: react-native <command>

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,8 +8,8 @@
 
 'use strict';
 
-var Dimensions = require('Dimensions');
 var React = require('react-native');
+var Dimensions = React.Dimensions;
 
 var deviceWidth = Dimensions.get('window').width;
 var deviceHeight = Dimensions.get('window').height;

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "panel",
     "sliding-up-panel"
   ],
-  "dependencies": {
+  "peerDependencies": {
+    "react-native": "^0.22.0"
   },
   "author": "Niña Manalo <nina.manalo19@gmail.com>",
   "license": {


### PR DESCRIPTION
Import dimensions from react-native.Dimensions instead.

Since react-native isn't a dependency anymore, `Dimensions` will not be available to your project as per the latest react-native dependency.

Add working react-native version into peerDependency.
